### PR TITLE
feat(`tempo.ts/wagmi`): `webAuthn` connector tweaks

### DIFF
--- a/.changeset/crisp-parts-feel.md
+++ b/.changeset/crisp-parts-feel.md
@@ -1,0 +1,5 @@
+---
+"tempo.ts": minor
+---
+
+**Breaking (`tempo.ts/wagmi`):** Changed default `expiry` of `Connector.webAuthn` connector access keys to one day (previously unlimited).

--- a/.changeset/sour-chicken-tie.md
+++ b/.changeset/sour-chicken-tie.md
@@ -1,0 +1,5 @@
+---
+"tempo.ts": minor
+---
+
+`tempo.ts/wagmi`: Added ability to pass `expiry` and `limits` to `webAuthn#grantAccessKey`.

--- a/.changeset/sparkly-ducks-talk.md
+++ b/.changeset/sparkly-ducks-talk.md
@@ -1,0 +1,5 @@
+---
+"tempo.ts": minor
+---
+
+**Breaking (`tempo.ts/wagmi`):** Removed `"lax"` option from `Connector.webAuthn#grantAccessKey` connector. The "lax" behavior is now the default. To opt-in to "strict mode", set `strict: true` in the `grantAccessKey` options.

--- a/src/ox/KeyAuthorization.ts
+++ b/src/ox/KeyAuthorization.ts
@@ -6,8 +6,6 @@ import * as Rlp from 'ox/Rlp'
 import type { Compute } from '../internal/types.js'
 import * as SignatureEnvelope from './SignatureEnvelope.js'
 
-const defaultExpiry = 0xffffffffffff
-
 /**
  * Key authorization for provisioning access keys.
  *
@@ -43,8 +41,8 @@ export type Rpc = Omit<
   'address' | 'signature' | 'type'
 > & {
   keyId: Address.Address
-  signature: SignatureEnvelope.SignatureEnvelopeRpc
   keyType: SignatureEnvelope.Type
+  signature: SignatureEnvelope.SignatureEnvelopeRpc
 }
 
 /** Signed representation of a Key Authorization. */
@@ -451,16 +449,16 @@ export function toRpc(authorization: Signed): Rpc {
   const {
     address,
     chainId = 0n,
-    expiry = defaultExpiry,
-    limits = [],
+    expiry,
+    limits,
     type,
     signature,
   } = authorization
 
   return {
     chainId: chainId === 0n ? '0x' : Hex.fromNumber(chainId),
-    expiry: Hex.fromNumber(expiry),
-    limits: limits.map(({ token, limit }) => ({
+    expiry: typeof expiry === 'number' ? Hex.fromNumber(expiry) : undefined,
+    limits: limits?.map(({ token, limit }) => ({
       token,
       limit: Hex.fromNumber(limit),
     })),


### PR DESCRIPTION
- Changed default `expiry` of `Connector.webAuthn` connector access keys to one day (previously unlimited).
- Added ability to pass `expiry` and `limits` to `webAuthn#grantAccessKey`.
- Removed `"lax"` option from `Connector.webAuthn#grantAccessKey` connector. The "lax" behavior is now the default. To opt-in to "strict mode", set `strict: true` in the `grantAccessKey` options.