### PR TITLE
add explicit path for next.js Handler docs

### DIFF
--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -104,6 +104,7 @@ export declare namespace from {
  * import { Handler } from 'tempo.ts/server'
  *
  * const handler = Handler.keyManager({
+ *   path: '/api/key', // Update this to match your API path, else it will return a 404
  *   kv: Kv.memory(),
  * })
  *
@@ -381,6 +382,7 @@ export declare namespace keyManager {
  * })
  *
  * const handler = Handler.feePayer({
+ *   path: '/api/fee', // Update this to match your API path, else it will return a 404
  *   account: privateKeyToAccount('0x...'),
  *   client,
  * })


### PR DESCRIPTION
Add `path` in Next.js docs for Handlers. 

You get a unexpected 404 error otherwise 