### PR TITLE
fix: bump viem, fix CI pipeline, migrate to tempoModerato

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         tag: 
-          - https://rpc.testnet.tempo.xyz
+          - https://rpc.moderato.tempo.xyz
 
     steps:
       - name: Clone repository

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Check code
         run: pnpm check
 
-      - name: Check build
-        run: pnpm build
-
       - name: Check types
         run: pnpm run check:types
+
+      - name: Check build
+        run: pnpm build
 
   test-localnet:
     name: 'Test Runtime (env: localnet, tag: ${{ matrix.tag }})'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm build
 
       - name: Check types
-        run: pnpm check:types
+        run: pnpm run check:types
 
   test-localnet:
     name: 'Test Runtime (env: localnet, tag: ${{ matrix.tag }})'

--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -4,7 +4,7 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "printWidth": 100,
-  "ignorePatterns": ["package.json"],
+  "ignorePatterns": ["package.json", ".github", "*.json", "*.jsonc", "*.md", "*.yaml", "*.yml", "*.html"],
   "experimentalSortImports": {
     "groups": [
       ["value-builtin", "value-external", "type-import", "value-internal", "type-internal"],

--- a/env.d.ts
+++ b/env.d.ts
@@ -2,7 +2,7 @@ interface ImportMetaEnv {
   readonly RPC_PORT: string
   readonly VITE_NODE_LOG: 'trace' | 'debug' | 'info' | 'warn' | 'error' | boolean | undefined
   readonly VITE_HTTP_LOG: 'true' | 'false'
-  readonly VITE_NODE_ENV: 'localnet' | 'testnet' | 'devnet'
+  readonly VITE_NODE_ENV: 'localnet' | 'moderato' | 'devnet'
   readonly VITE_NODE_TAG: string
   readonly VITE_RPC_CREDENTIALS: string
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,13 +1,6 @@
 interface ImportMetaEnv {
   readonly RPC_PORT: string
-  readonly VITE_NODE_LOG:
-    | 'trace'
-    | 'debug'
-    | 'info'
-    | 'warn'
-    | 'error'
-    | boolean
-    | undefined
+  readonly VITE_NODE_LOG: 'trace' | 'debug' | 'info' | 'warn' | 'error' | boolean | undefined
   readonly VITE_HTTP_LOG: 'true' | 'false'
   readonly VITE_NODE_ENV: 'localnet' | 'testnet' | 'devnet'
   readonly VITE_NODE_TAG: string

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"@changesets/changelog-github": "^0.6.0",
 		"@changesets/cli": "^2.30.0",
 		"@types/express": "^5.0.6",
+		"@types/http-proxy": "^1.17.17",
 		"@types/node": "^25.3.3",
 		"@types/react": "catalog:default",
 		"@types/react-dom": "catalog:default",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   react: ^19.1.1
   react-dom: ^19.1.1
   tempo.ts: workspace:*
-  viem: ^2.46.2
+  viem: ^2.47.0
 
 importers:
 
@@ -49,6 +49,9 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
+      '@types/http-proxy':
+        specifier: ^1.17.17
+        version: 1.17.17
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
@@ -104,8 +107,8 @@ importers:
         specifier: catalog:default
         version: 5.9.3
       viem:
-        specifier: ^2.46.2
-        version: 2.46.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13)
+        specifier: ^2.47.0
+        version: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.3)(lightningcss@1.30.2)(yaml@2.8.2)
@@ -992,6 +995,9 @@ packages:
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/http-proxy@1.17.17':
+    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2651,8 +2657,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.46.2:
-    resolution: {integrity: sha512-w8Qv5Vyo7TfXcH3vgmxRa1NRvzJCDy2aSGSRsJn3503nC/qVbgEQ+n3aj/CkqWXbloudZh97h5o5aQrQSVGy0w==}
+  viem@2.47.2:
+    resolution: {integrity: sha512-etDIwDgmDiGaPg8rUbJtUFuC3/nAJCbhMYyfh5dOcqNNkzBWTNcS2VluPSM5JVo+9U3b2hle2RkBEq3+xyvlvg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -3617,6 +3623,10 @@ snapshots:
       '@types/serve-static': 2.2.0
 
   '@types/http-errors@2.0.5': {}
+
+  '@types/http-proxy@1.17.17':
+    dependencies:
+      '@types/node': 25.3.3
 
   '@types/node@12.20.55': {}
 
@@ -5257,7 +5267,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.46.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13):
+  viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   react: ^19.1.1
   react-dom: ^19.1.1
   typescript: ^5.9.3
-  viem: ^2.46.2
+  viem: ^2.47.0
   wagmi: ^3.4.2
 
 onlyBuiltDependencies:

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -45,11 +45,8 @@ export type Filter<
  * //   ^? true
  * ```
  */
-export type IsNarrowable<T, U> = IsNever<
-  (T extends U ? true : false) & (U extends T ? false : true)
-> extends true
-  ? false
-  : true
+export type IsNarrowable<T, U> =
+  IsNever<(T extends U ? true : false) & (U extends T ? false : true)> extends true ? false : true
 
 /**
  * Checks if `T` is `never`
@@ -88,10 +85,7 @@ export type Mutable<type extends object> = {
  *
  * @internal
  */
-export type Or<T extends readonly unknown[]> = T extends readonly [
-  infer Head,
-  ...infer Tail,
-]
+export type Or<T extends readonly unknown[]> = T extends readonly [infer Head, ...infer Tail]
   ? Head extends true
     ? true
     : Or<Tail>
@@ -115,11 +109,7 @@ export type IsUndefined<T> = [undefined] extends [T] ? true : false
  *
  * @internal
  */
-export type IsUnknown<T> = unknown extends T
-  ? [T] extends [null]
-    ? false
-    : true
-  : false
+export type IsUnknown<T> = unknown extends T ? ([T] extends [null] ? false : true) : false
 
 /** @internal */
 export type MaybePromise<T> = T | Promise<T>
@@ -157,11 +147,9 @@ export type Assign<T, U> = Assign_inner<T, U> & U
 
 /** @internal */
 export type Assign_inner<T, U> = {
-  [K in keyof T as K extends keyof U
-    ? U[K] extends void
-      ? never
-      : K
-    : K]: K extends keyof U ? U[K] : T[K]
+  [K in keyof T as K extends keyof U ? (U[K] extends void ? never : K) : K]: K extends keyof U
+    ? U[K]
+    : T[K]
 }
 
 /**
@@ -182,10 +170,7 @@ export type NoUndefined<T> = T extends undefined ? never : T
  *
  * @internal
  */
-export type Omit<type, keys extends keyof type> = Pick<
-  type,
-  Exclude<keyof type, keys>
->
+export type Omit<type, keys extends keyof type> = Pick<type, Exclude<keyof type, keys>>
 
 /**
  * Creates a type that is a partial of T, but with the required keys K.
@@ -198,8 +183,7 @@ export type Omit<type, keys extends keyof type> = Pick<
  *
  * @internal
  */
-export type PartialBy<T, K extends keyof T> = Omit<T, K> &
-  ExactPartial<Pick<T, K>>
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & ExactPartial<Pick<T, K>>
 
 export type RecursiveArray<T> = T | readonly RecursiveArray<T>[]
 
@@ -214,8 +198,7 @@ export type RecursiveArray<T> = T | readonly RecursiveArray<T>[]
  *
  * @internal
  */
-export type RequiredBy<T, K extends keyof T> = Omit<T, K> &
-  ExactRequired<Pick<T, K>>
+export type RequiredBy<T, K extends keyof T> = Omit<T, K> & ExactRequired<Pick<T, K>>
 
 /**
  * Returns truthy if `array` contains `value`.
@@ -228,10 +211,10 @@ export type RequiredBy<T, K extends keyof T> = Omit<T, K> &
  *
  * @internal
  */
-export type Some<
-  array extends readonly unknown[],
+export type Some<array extends readonly unknown[], value> = array extends readonly [
   value,
-> = array extends readonly [value, ...unknown[]]
+  ...unknown[],
+]
   ? true
   : array extends readonly [unknown, ...infer rest]
     ? Some<rest, value>
@@ -249,18 +232,16 @@ export type Some<
  * //   ^? type Result = ['Error: Custom error message']
  * ```
  */
-export type TypeErrorMessage<messages extends string | string[]> =
-  messages extends string
-    ? [
-        // Surrounding with array to prevent `messages` from being widened to `string`
-        `Error: ${messages}`,
-      ]
-    : {
-        [key in keyof messages]: messages[key] extends infer message extends
-          string
-          ? `Error: ${message}`
-          : never
-      }
+export type TypeErrorMessage<messages extends string | string[]> = messages extends string
+  ? [
+      // Surrounding with array to prevent `messages` from being widened to `string`
+      `Error: ${messages}`,
+    ]
+  : {
+      [key in keyof messages]: messages[key] extends infer message extends string
+        ? `Error: ${message}`
+        : never
+    }
 
 /** @internal */
 export type UnionToTuple<
@@ -270,17 +251,12 @@ export type UnionToTuple<
 > = [union] extends [never] ? [] : [...UnionToTuple<Exclude<union, last>>, last]
 
 /** @internal */
-export type LastInUnion<U> = UnionToIntersection<
-  U extends unknown ? (x: U) => 0 : never
-> extends (x: infer l) => 0
-  ? l
-  : never
+export type LastInUnion<U> =
+  UnionToIntersection<U extends unknown ? (x: U) => 0 : never> extends (x: infer l) => 0 ? l : never
 
 /** @internal */
 export type UnionToIntersection<union> = (
-  union extends unknown
-    ? (arg: union) => 0
-    : never
+  union extends unknown ? (arg: union) => 0 : never
 ) extends (arg: infer i) => 0
   ? i
   : never
@@ -293,10 +269,9 @@ export type IsUnion<
 > = union extends union2 ? ([union2] extends [union] ? false : true) : never
 
 /** @internal */
-export type MaybePartial<
-  type,
-  enabled extends boolean | undefined,
-> = enabled extends true ? Compute<ExactPartial<type>> : type
+export type MaybePartial<type, enabled extends boolean | undefined> = enabled extends true
+  ? Compute<ExactPartial<type>>
+  : type
 
 export type ExactPartial<type> = {
   [key in keyof type]?: type[key] | undefined
@@ -339,10 +314,7 @@ export type Undefined<type> = {
  * Loose version of {@link Omit}
  * @internal
  */
-export type LooseOmit<type, keys extends string> = Pick<
-  type,
-  Exclude<keyof type, keys>
->
+export type LooseOmit<type, keys extends string> = Pick<type, Exclude<keyof type, keys>>
 
 ///////////////////////////////////////////////////////////////////////////
 // Union types
@@ -365,9 +337,7 @@ export type UnionLooseOmit<type, keys extends string> = type extends any
  *
  * @internal
  */
-export type UnionOmit<type, keys extends keyof type> = type extends any
-  ? Omit<type, keys>
-  : never
+export type UnionOmit<type, keys extends keyof type> = type extends any ? Omit<type, keys> : never
 
 /**
  * Construct a type with the properties of union type T except for those in type K.
@@ -379,9 +349,7 @@ export type UnionOmit<type, keys extends keyof type> = type extends any
  *
  * @internal
  */
-export type UnionPick<type, keys extends keyof type> = type extends any
-  ? Pick<type, keys>
-  : never
+export type UnionPick<type, keys extends keyof type> = type extends any ? Pick<type, keys> : never
 
 /**
  * Creates a type that is a partial of T, but with the required keys K.
@@ -394,9 +362,7 @@ export type UnionPick<type, keys extends keyof type> = type extends any
  *
  * @internal
  */
-export type UnionPartialBy<T, K extends keyof T> = T extends any
-  ? PartialBy<T, K>
-  : never
+export type UnionPartialBy<T, K extends keyof T> = T extends any ? PartialBy<T, K> : never
 
 /**
  * Creates a type that is T with the required keys K.
@@ -409,6 +375,4 @@ export type UnionPartialBy<T, K extends keyof T> = T extends any
  *
  * @internal
  */
-export type UnionRequiredBy<T, K extends keyof T> = T extends any
-  ? RequiredBy<T, K>
-  : never
+export type UnionRequiredBy<T, K extends keyof T> = T extends any ? RequiredBy<T, K> : never

--- a/src/server/Handler.test.ts
+++ b/src/server/Handler.test.ts
@@ -6,15 +6,8 @@ import * as Base64 from 'ox/Base64'
 import * as Hex from 'ox/Hex'
 import { sendTransactionSync } from 'viem/actions'
 import { withFeePayer } from 'viem/tempo'
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
 import { accounts, getClient, http } from '../../test/server/config.js'
 import { createServer, type Server } from '../../test/server/utils.js'
 import * as Handler from './Handler.js'
@@ -33,9 +26,7 @@ describe('from', () => {
       expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
         'GET, POST, PUT, DELETE, OPTIONS',
       )
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
-        'Content-Type',
-      )
+      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type')
     })
 
     test('behavior: cors = false disables CORS headers', async () => {
@@ -64,18 +55,12 @@ describe('from', () => {
       const response = await handler.fetch(new Request('http://localhost/test'))
 
       expect(response.status).toBe(200)
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
-        'https://example.com',
-      )
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-        'GET, POST',
-      )
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://example.com')
+      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST')
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
         'Content-Type, Authorization',
       )
-      expect(response.headers.get('Access-Control-Allow-Credentials')).toBe(
-        'true',
-      )
+      expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true')
       expect(response.headers.get('Access-Control-Max-Age')).toBe('86400')
     })
 
@@ -119,9 +104,7 @@ describe('from', () => {
 
       const response = await handler.fetch(new Request('http://localhost/test'))
 
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
-        'https://override.com',
-      )
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://override.com')
     })
   })
 })
@@ -143,9 +126,7 @@ describe('compose', () => {
     }
 
     {
-      const response = await handler.fetch(
-        new Request('http://localhost/test2'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/test2'))
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test2')
     }
@@ -163,17 +144,13 @@ describe('compose', () => {
     expect(handler).toBeDefined()
 
     {
-      const response = await handler.fetch(
-        new Request('http://localhost/api/test'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/api/test'))
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test')
     }
 
     {
-      const response = await handler.fetch(
-        new Request('http://localhost/api/test2'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/api/test2'))
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test2')
     }
@@ -200,18 +177,14 @@ describe('compose', () => {
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test')
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-        'POST, OPTIONS',
-      )
+      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
         'Content-Type, Authorization',
       )
     }
 
     {
-      const response = await handler.fetch(
-        new Request('http://localhost/test2'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/test2'))
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test2')
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
@@ -235,21 +208,15 @@ describe('compose', () => {
     })
 
     {
-      const response = await handler.fetch(
-        new Request('http://localhost/api/test'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/api/test'))
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test')
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-        'POST, OPTIONS',
-      )
+      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
     }
 
     {
-      const response = await handler.fetch(
-        new Request('http://localhost/api/test2'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/api/test2'))
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('test2')
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
@@ -280,12 +247,8 @@ describe('compose', () => {
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('')
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-      'POST, OPTIONS',
-    )
-    expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
-      'Content-Type, Authorization',
-    )
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization')
     expect(response.headers.get('Access-Control-Max-Age')).toBe('86400')
   })
 
@@ -301,9 +264,7 @@ describe('compose', () => {
       headers,
     })
 
-    const response = await handler.fetch(
-      new Request('http://localhost/nonexistent'),
-    )
+    const response = await handler.fetch(new Request('http://localhost/nonexistent'))
 
     expect(response.status).toBe(404)
     expect(await response.text()).toBe('Not Found')
@@ -376,12 +337,8 @@ describe('compose', () => {
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('test')
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-      'POST, OPTIONS',
-    )
-    expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
-      'Content-Type, Authorization',
-    )
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization')
   })
 
   describe('integration', () => {
@@ -432,9 +389,7 @@ describe('compose', () => {
       const app = new Elysia().all('*', ({ request }) => handler.fetch(request))
 
       {
-        const response = await app.handle(
-          new Request('http://localhost/api/foo'),
-        )
+        const response = await app.handle(new Request('http://localhost/api/foo'))
         expect(await response.text()).toBe('foo')
       }
 
@@ -552,9 +507,7 @@ describe('from', () => {
 
   test('.listener', async () => {
     const handler = Handler.from()
-    handler.get('/test', () =>
-      Response.json({ message: 'hello from listener' }),
-    )
+    handler.get('/test', () => Response.json({ message: 'hello from listener' }))
 
     const server = await createServer(handler.listener)
 
@@ -580,12 +533,8 @@ describe('from', () => {
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('test')
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-      'POST, OPTIONS',
-    )
-    expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
-      'Content-Type, Authorization',
-    )
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization')
   })
 
   test('behavior: headers + OPTIONS', async () => {
@@ -608,12 +557,8 @@ describe('from', () => {
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('')
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-      'POST, OPTIONS',
-    )
-    expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
-      'Content-Type, Authorization',
-    )
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization')
     expect(response.headers.get('Access-Control-Max-Age')).toBe('86400')
   })
 
@@ -625,9 +570,7 @@ describe('from', () => {
     const handler = Handler.from({ headers })
     handler.get('/test', () => new Response('test'))
 
-    const response = await handler.fetch(
-      new Request('http://localhost/nonexistent'),
-    )
+    const response = await handler.fetch(new Request('http://localhost/nonexistent'))
 
     expect(response.status).toBe(404)
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
@@ -669,12 +612,8 @@ describe('from', () => {
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('test')
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
-      'POST, OPTIONS',
-    )
-    expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
-      'Content-Type, Authorization',
-    )
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS')
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization')
   })
 
   describe('integration', () => {
@@ -791,14 +730,11 @@ describe('keyManager', () => {
 
   describe('GET /challenge', () => {
     test('default', async () => {
-      const response = await handler.fetch(
-        new Request('http://localhost/challenge'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/challenge'))
 
       expect(response.status).toBe(200)
 
-      const data =
-        (await response.json()) as Handler.keyManager.ChallengeResponse
+      const data = (await response.json()) as Handler.keyManager.ChallengeResponse
       expect(Hex.validate(data.challenge)).toBe(true)
 
       // Verify challenge was stored in KV
@@ -812,14 +748,11 @@ describe('keyManager', () => {
         rp: 'example.com',
       })
 
-      const response = await handlerWithRpId.fetch(
-        new Request('http://localhost/challenge'),
-      )
+      const response = await handlerWithRpId.fetch(new Request('http://localhost/challenge'))
 
       expect(response.status).toBe(200)
 
-      const data =
-        (await response.json()) as Handler.keyManager.ChallengeResponse
+      const data = (await response.json()) as Handler.keyManager.ChallengeResponse
       expect(data.rp).toEqual({
         id: 'example.com',
         name: 'example.com',
@@ -834,9 +767,7 @@ describe('keyManager', () => {
 
       await kv.set(`credential:${credentialId}`, publicKey)
 
-      const response = await handler.fetch(
-        new Request(`http://localhost/${credentialId}`),
-      )
+      const response = await handler.fetch(new Request(`http://localhost/${credentialId}`))
 
       expect(response.status).toBe(200)
 
@@ -845,9 +776,7 @@ describe('keyManager', () => {
     })
 
     test('behavior: returns 404 for non-existent credential', async () => {
-      const response = await handler.fetch(
-        new Request('http://localhost/non-existent'),
-      )
+      const response = await handler.fetch(new Request('http://localhost/non-existent'))
 
       expect(response.status).toBe(404)
       expect(await response.text()).toBe('Credential not found')
@@ -858,8 +787,7 @@ describe('keyManager', () => {
     test('default', async () => {
       const credentialId = credential.id
       const challenge = Base64.toHex(
-        JSON.parse(Base64.toString(credential.response.clientDataJSON))
-          .challenge,
+        JSON.parse(Base64.toString(credential.response.clientDataJSON)).challenge,
       )
 
       // Store the challenge first
@@ -953,9 +881,7 @@ describe('keyManager', () => {
       }
 
       const challenge = Base64.toHex(
-        JSON.parse(
-          Base64.toString(invalidCredential.response.clientDataJSON as string),
-        ).challenge,
+        JSON.parse(Base64.toString(invalidCredential.response.clientDataJSON as string)).challenge,
       )
       await kv.set(`challenge:${challenge}`, '1')
 
@@ -982,8 +908,7 @@ describe('keyManager', () => {
       })
 
       const challenge = Base64.toHex(
-        JSON.parse(Base64.toString(credential.response.clientDataJSON))
-          .challenge,
+        JSON.parse(Base64.toString(credential.response.clientDataJSON)).challenge,
       )
       await kv.set(`challenge:${challenge}`, '1')
 
@@ -1010,8 +935,7 @@ describe('keyManager', () => {
       })
 
       const challenge = Base64.toHex(
-        JSON.parse(Base64.toString(credential.response.clientDataJSON))
-          .challenge,
+        JSON.parse(Base64.toString(credential.response.clientDataJSON)).challenge,
       )
       await kv.set(`challenge:${challenge}`, '1')
 
@@ -1031,9 +955,7 @@ describe('keyManager', () => {
 
     test('behavior: returns 400 when user not present flag is not set', async () => {
       // Create credential with UP flag not set (bit 0 = 0)
-      const authenticatorDataBytes = Base64.toBytes(
-        credential.response.authenticatorData,
-      )
+      const authenticatorDataBytes = Base64.toBytes(credential.response.authenticatorData)
       // Clear the UP flag (bit 0) in byte 32
       authenticatorDataBytes[32] = authenticatorDataBytes[32]! & ~0x01
 
@@ -1046,8 +968,7 @@ describe('keyManager', () => {
       }
 
       const challenge = Base64.toHex(
-        JSON.parse(Base64.toString(credential.response.clientDataJSON))
-          .challenge,
+        JSON.parse(Base64.toString(credential.response.clientDataJSON)).challenge,
       )
       await kv.set(`challenge:${challenge}`, '1')
 

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -355,7 +355,7 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   chain: tempoTestnet.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   chain: tempoModerato.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
  *   transport: http(),
  * })
  *
@@ -379,7 +379,7 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   chain: tempoTestnet.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   chain: tempoModerato.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
  *   transport: http(),
  * })
  *
@@ -402,7 +402,7 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   chain: tempoTestnet.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   chain: tempoModerato.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
  *   transport: http(),
  * })
  *
@@ -427,7 +427,7 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   chain: tempoTestnet.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   chain: tempoModerato.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
  *   transport: http(),
  * })
  *
@@ -451,7 +451,7 @@ export declare namespace keyManager {
  *
  * const client = createClient({
  *   account: privateKeyToAccount('0x...'),
- *   chain: tempoTestnet.extend({
+ *   chain: tempoModerato.extend({
  *     feeToken: '0x20c0000000000000000000000000000000000001',
  *   }),
  *   transport: http(),
@@ -475,7 +475,7 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   chain: tempoTestnet.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   chain: tempoModerato.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
  *   transport: http(),
  * })
  *
@@ -497,7 +497,7 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   chain: tempoTestnet.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   chain: tempoModerato.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
  *   transport: http(),
  * })
  *

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -12,6 +12,7 @@ import { type Chain, type Client, createClient, type Transport } from 'viem'
 import type { LocalAccount } from 'viem/accounts'
 import { signTransaction } from 'viem/actions'
 import { Transaction } from 'viem/tempo'
+
 import type { OneOf } from '../internal/types.js'
 import * as RequestListener from './internal/requestListener.js'
 import type * as Kv from './Kv.js'
@@ -20,18 +21,14 @@ export type Handler = Router & {
   listener: (req: any, res: any) => void
 }
 
-export function compose(
-  handlers: Handler[],
-  options: compose.Options = {},
-): Handler {
+export function compose(handlers: Handler[], options: compose.Options = {}): Handler {
   const path = options.path ?? '/'
 
   return from({
     ...options,
     async defaultHandler(context) {
       const url = new URL(context.request.url)
-      if (!url.pathname.startsWith(path))
-        return new Response('Not Found', { status: 404 })
+      if (!url.pathname.startsWith(path)) return new Response('Not Found', { status: 404 })
 
       url.pathname = url.pathname.replace(path, '')
       for (const handler of handlers) {
@@ -216,8 +213,7 @@ export function keyManager(options: keyManager.Options) {
   const path = options.path ?? ''
 
   const rp = (() => {
-    if (typeof options.rp === 'string')
-      return { id: options.rp, name: options.rp }
+    if (typeof options.rp === 'string') return { id: options.rp, name: options.rp }
     if (options.rp)
       return {
         id: options.rp.id,
@@ -244,7 +240,7 @@ export function keyManager(options: keyManager.Options) {
 
   // Get public key for a credential
   router.get(`${path}/:id`, async ({ params }) => {
-    const { id } = params
+    const { id } = params as { id: string }
 
     const publicKey = await kv.get<Hex.Hex>(`credential:${id}`)
 
@@ -257,13 +253,11 @@ export function keyManager(options: keyManager.Options) {
 
   // Set public key for a credential
   router.post(`${path}/:id`, async ({ params, request }) => {
-    const { id } = params
+    const { id } = params as { id: string }
     const { credential, publicKey } = (await request.json()) as any
 
-    if (!credential)
-      return Response.json({ error: 'Missing `credential`' }, { status: 400 })
-    if (!publicKey)
-      return Response.json({ error: 'Missing `publicKey`' }, { status: 400 })
+    if (!credential) return Response.json({ error: 'Missing `credential`' }, { status: 400 })
+    if (!publicKey) return Response.json({ error: 'Missing `publicKey`' }, { status: 400 })
 
     // Decode and verify clientDataJSON
     const clientDataJSON = JSON.parse(
@@ -274,17 +268,11 @@ export function keyManager(options: keyManager.Options) {
     const challenge = Base64.toHex(clientDataJSON.challenge)
 
     if (!(await kv.get<string>(`challenge:${challenge}`)))
-      return Response.json(
-        { error: 'Invalid or expired `challenge`' },
-        { status: 400 },
-      )
+      return Response.json({ error: 'Invalid or expired `challenge`' }, { status: 400 })
 
     // Verify type
     if (clientDataJSON.type !== 'webauthn.create')
-      return Response.json(
-        { error: 'Invalid `clientDataJSON.type`' },
-        { status: 400 },
-      )
+      return Response.json({ error: 'Invalid `clientDataJSON.type`' }, { status: 400 })
 
     // Verify origin
     if (
@@ -292,28 +280,18 @@ export function keyManager(options: keyManager.Options) {
       !rp.id.includes('localhost') &&
       clientDataJSON.origin !== new URL(`https://${rp.id}`).origin
     )
-      return Response.json(
-        { error: 'Invalid `clientDataJSON.origin`' },
-        { status: 400 },
-      )
+      return Response.json({ error: 'Invalid `clientDataJSON.origin`' }, { status: 400 })
 
     // Parse authenticatorData
-    const authenticatorData = Base64.toBytes(
-      (credential.response as any).authenticatorData,
-    )
+    const authenticatorData = Base64.toBytes((credential.response as any).authenticatorData)
 
     // Parse flags (byte 32)
     const flags = authenticatorData[32]
-    if (!flags)
-      return Response.json(
-        { error: 'Invalid `authenticatorData`' },
-        { status: 400 },
-      )
+    if (!flags) return Response.json({ error: 'Invalid `authenticatorData`' }, { status: 400 })
 
     // Check User Present (UP) flag (bit 0)
     const userPresent = (flags & 0x01) !== 0
-    if (!userPresent)
-      return Response.json({ error: 'User not present' }, { status: 400 })
+    if (!userPresent) return Response.json({ error: 'User not present' }, { status: 400 })
 
     // Consume the challenge (delete it so it can't be reused)
     await kv.delete(`challenge:${challenge}`)
@@ -585,8 +563,7 @@ export function feePayer(options: feePayer.Options) {
 
       if (!transaction.signature || !transaction.from)
         throw new RpcResponse.InvalidParamsError({
-          message:
-            'Transaction must be signed by the sender before fee payer signing.',
+          message: 'Transaction must be signed by the sender before fee payer signing.',
         })
 
       const serializedTransaction = await signTransaction(client, {
@@ -596,9 +573,7 @@ export function feePayer(options: feePayer.Options) {
       })
 
       if (method === 'eth_signRawTransaction')
-        return Response.json(
-          RpcResponse.from({ result: serializedTransaction }, { request }),
-        )
+        return Response.json(RpcResponse.from({ result: serializedTransaction }, { request }))
 
       const result = await (client as any).request({
         method,
@@ -659,19 +634,12 @@ function corsToHeaders(cors?: boolean | from.Cors): Headers {
   const config = cors === true || cors === undefined ? {} : cors
 
   const headers = new Headers()
-  const origin = Array.isArray(config.origin)
-    ? config.origin.join(', ')
-    : (config.origin ?? '*')
+  const origin = Array.isArray(config.origin) ? config.origin.join(', ') : (config.origin ?? '*')
   headers.set('Access-Control-Allow-Origin', origin)
-  headers.set(
-    'Access-Control-Allow-Methods',
-    config.methods ?? 'GET, POST, PUT, DELETE, OPTIONS',
-  )
+  headers.set('Access-Control-Allow-Methods', config.methods ?? 'GET, POST, PUT, DELETE, OPTIONS')
   headers.set('Access-Control-Allow-Headers', config.headers ?? 'Content-Type')
-  if (config.credentials)
-    headers.set('Access-Control-Allow-Credentials', 'true')
-  if (config.maxAge !== undefined)
-    headers.set('Access-Control-Max-Age', String(config.maxAge))
+  if (config.credentials) headers.set('Access-Control-Allow-Credentials', 'true')
+  if (config.maxAge !== undefined) headers.set('Access-Control-Max-Age', String(config.maxAge))
 
   return headers
 }
@@ -681,8 +649,7 @@ function headers(headers: Headers): Middleware {
   return async (_, next) => {
     const response = await next()
     const responseHeaders = new Headers(response.headers)
-    for (const [key, value] of headers.entries())
-      responseHeaders.set(key, value)
+    for (const [key, value] of headers.entries()) responseHeaders.set(key, value)
     return new Response(response.body, {
       headers: responseHeaders,
       status: response.status,
@@ -694,7 +661,6 @@ function headers(headers: Headers): Middleware {
 /** @internal */
 function preflight(headers: Headers): Middleware {
   return async (context) => {
-    if (context.request.method === 'OPTIONS')
-      return new Response(null, { headers })
+    if (context.request.method === 'OPTIONS') return new Response(null, { headers })
   }
 }

--- a/src/server/internal/requestListener.ts
+++ b/src/server/internal/requestListener.ts
@@ -98,8 +98,8 @@ function internalServerError(): Response {
   return new Response(
     // "Internal Server Error"
     new Uint8Array([
-      73, 110, 116, 101, 114, 110, 97, 108, 32, 83, 101, 114, 118, 101, 114, 32,
-      69, 114, 114, 111, 114,
+      73, 110, 116, 101, 114, 110, 97, 108, 32, 83, 101, 114, 118, 101, 114, 32, 69, 114, 114, 111,
+      114,
     ]),
     {
       headers: {
@@ -137,8 +137,7 @@ export function createRequest(
   const headers = createHeaders(req)
 
   const protocol =
-    options?.protocol ??
-    ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
+    options?.protocol ?? ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
   const host = options?.host ?? headers.get('Host') ?? 'localhost'
   const url = new URL(req.url!, `${protocol}//${host}`)
 
@@ -148,9 +147,7 @@ export function createRequest(
     init.body = new ReadableStream({
       start(controller) {
         req.on('data', (chunk) => {
-          controller.enqueue(
-            new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
-          )
+          controller.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
         })
         req.on('end', () => {
           controller.close()
@@ -175,9 +172,7 @@ export function createRequest(
  * @param req The incoming request object.
  * @returns A headers object.
  */
-export function createHeaders(
-  req: http.IncomingMessage | http2.Http2ServerRequest,
-): Headers {
+export function createHeaders(req: http.IncomingMessage | http2.Http2ServerRequest): Headers {
   const headers = new Headers()
 
   const rawHeaders = req.rawHeaders
@@ -229,9 +224,7 @@ export async function sendResponse(
   res.end()
 }
 
-export async function* readStream(
-  stream: ReadableStream<Uint8Array>,
-): AsyncIterable<Uint8Array> {
+export async function* readStream(stream: ReadableStream<Uint8Array>): AsyncIterable<Uint8Array> {
   const reader = stream.getReader()
 
   while (true) {
@@ -268,9 +261,7 @@ export interface ClientAddress {
  *
  * [MDN `Response` Reference](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  */
-export type ErrorHandler = (
-  error: unknown,
-) => undefined | Response | Promise<undefined | Response>
+export type ErrorHandler = (error: unknown) => undefined | Response | Promise<undefined | Response>
 
 /**
  * A function that handles an incoming request and returns a response.
@@ -279,7 +270,4 @@ export type ErrorHandler = (
  *
  * [MDN `Response` Reference](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  */
-export type FetchHandler = (
-  request: Request,
-  client: ClientAddress,
-) => Response | Promise<Response>
+export type FetchHandler = (request: Request, client: ClientAddress) => Response | Promise<Response>

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,4 +1,4 @@
-import { tempoDevnet, tempoLocalnet, tempoTestnet } from 'viem/chains'
+import { tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
 
 export const addresses = {
   alphaUsd: '0x20c0000000000000000000000000000000000001',
@@ -11,7 +11,7 @@ export const id =
 
 export const nodeEnv = import.meta.env.VITE_NODE_ENV || 'localnet'
 export const chainId = (() => {
-  if (nodeEnv === 'testnet') return tempoTestnet.id
+  if (nodeEnv === 'moderato') return tempoModerato.id
   if (nodeEnv === 'devnet') return tempoDevnet.id
   return tempoLocalnet.id
 })()
@@ -24,7 +24,7 @@ export const fetchOptions = {
 
 export const rpcUrl = (() => {
   const env = import.meta.env.VITE_NODE_ENV
-  if (env === 'testnet') return tempoTestnet.rpcUrls.default.http[0]
+  if (env === 'moderato') return tempoModerato.rpcUrls.default.http[0]
   if (env === 'devnet') return tempoDevnet.rpcUrls.default.http[0]
   return `http://localhost:${import.meta.env.RPC_PORT ?? '8545'}/${id}`
 })()

--- a/test/config.ts
+++ b/test/config.ts
@@ -6,8 +6,7 @@ export const addresses = {
 
 export const id =
   (typeof process !== 'undefined' &&
-    Number(process.env.VITEST_POOL_ID ?? 1) +
-      Math.floor(Math.random() * 10_000)) ||
+    Number(process.env.VITEST_POOL_ID ?? 1) + Math.floor(Math.random() * 10_000)) ||
   1 + Math.floor(Math.random() * 10_000)
 
 export const nodeEnv = import.meta.env.VITE_NODE_ENV || 'localnet'

--- a/test/prool.ts
+++ b/test/prool.ts
@@ -1,12 +1,12 @@
 import { Instance, Server } from 'prool'
 import * as TestContainers from 'prool/testcontainers'
 import { createClient, http } from 'viem'
+
 import { fetchOptions } from './config.js'
 
 export async function setupServer({ port }: { port: number }) {
   const tag = await (async () => {
-    if (!import.meta.env.VITE_NODE_TAG?.startsWith('http'))
-      return import.meta.env.VITE_NODE_TAG
+    if (!import.meta.env.VITE_NODE_TAG?.startsWith('http')) return import.meta.env.VITE_NODE_TAG
 
     const client = createClient({
       transport: http(import.meta.env.VITE_NODE_TAG, {

--- a/test/server/config.ts
+++ b/test/server/config.ts
@@ -9,28 +9,20 @@ import {
   type Account as viem_Account,
   http as viem_http,
 } from 'viem'
-import {
-  type Address,
-  english,
-  generateMnemonic,
-  type JsonRpcAccount,
-} from 'viem/accounts'
+import { type Address, english, generateMnemonic, type JsonRpcAccount } from 'viem/accounts'
 import { tempoLocalnet, tempoTestnet } from 'viem/chains'
 import {
   // biome-ignore lint/correctness/noUnusedImports: This is needed to ensure TypeScript can reference viem/tempo types portably
   type z_TokenId as _,
   Account,
-  Actions,
-  Addresses,
-  Tick,
 } from 'viem/tempo'
+
 import { rpcUrl } from '../config.js'
 
 export const nodeEnv = import.meta.env.VITE_NODE_ENV || 'localnet'
 
 const accountsMnemonic = (() => {
-  if (nodeEnv === 'localnet')
-    return 'test test test test test test test test test test test junk'
+  if (nodeEnv === 'localnet') return 'test test test test test test test test test test test junk'
   return generateMnemonic(english)
 })()
 
@@ -51,11 +43,7 @@ export const chain = (() => {
   return tempoLocalnet
 })()
 
-export function debugOptions({
-  rpcUrl,
-}: {
-  rpcUrl: string
-}): HttpTransportConfig | undefined {
+export function debugOptions({ rpcUrl }: { rpcUrl: string }): HttpTransportConfig | undefined {
   if (import.meta.env.VITE_HTTP_LOG !== 'true') return undefined
   return {
     async onFetchRequest(_, init) {
@@ -83,17 +71,12 @@ export function getClient<
   accountOrAddress extends viem_Account | Address | undefined = undefined,
 >(
   parameters: Partial<
-    Pick<
-      ClientConfig<Transport, chain, accountOrAddress>,
-      'account' | 'chain' | 'transport'
-    >
+    Pick<ClientConfig<Transport, chain, accountOrAddress>, 'account' | 'chain' | 'transport'>
   > = {},
 ): Client<
   Transport,
   chain,
-  accountOrAddress extends Address
-    ? JsonRpcAccount<accountOrAddress>
-    : accountOrAddress
+  accountOrAddress extends Address ? JsonRpcAccount<accountOrAddress> : accountOrAddress
 > {
   return createClient({
     pollingInterval: 100,
@@ -114,6 +97,4 @@ type FixedArray<
   type,
   count extends number,
   result extends readonly type[] = [],
-> = result['length'] extends count
-  ? result
-  : FixedArray<type, count, readonly [...result, type]>
+> = result['length'] extends count ? result : FixedArray<type, count, readonly [...result, type]>

--- a/test/server/config.ts
+++ b/test/server/config.ts
@@ -10,7 +10,7 @@ import {
   http as viem_http,
 } from 'viem'
 import { type Address, english, generateMnemonic, type JsonRpcAccount } from 'viem/accounts'
-import { tempoLocalnet, tempoTestnet } from 'viem/chains'
+import { tempoLocalnet, tempoModerato } from 'viem/chains'
 import {
   // biome-ignore lint/correctness/noUnusedImports: This is needed to ensure TypeScript can reference viem/tempo types portably
   type z_TokenId as _,
@@ -39,7 +39,7 @@ export const addresses = {
 } as const
 
 export const chain = (() => {
-  if (nodeEnv === 'testnet') return tempoTestnet
+  if (nodeEnv === 'moderato') return tempoModerato
   return tempoLocalnet
 })()
 

--- a/test/server/setup.ts
+++ b/test/server/setup.ts
@@ -1,6 +1,7 @@
 import { parseUnits } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
 import { afterAll, beforeAll } from 'vitest'
+
 import { rpcUrl } from '../config.js'
 import { accounts, getClient, nodeEnv } from './config.js'
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,9 +21,7 @@ export default defineConfig({
           },
           name: 'server',
           root: './src/server',
-          globalSetup: [
-            join(import.meta.dirname, './test/server/setup.global.ts'),
-          ],
+          globalSetup: [join(import.meta.dirname, './test/server/setup.global.ts')],
           sequence: { groupOrder: 2 },
           setupFiles: [join(import.meta.dirname, './test/server/setup.ts')],
         },


### PR DESCRIPTION
## Summary

- **Bump viem** from `^2.46.2` to `^2.47.0` to support `nonceKey: 'expiring'` literal (TIP-1009)
- **Fix CI type errors** — add type assertions for router params, add missing dev dependencies (`@typescript/native-preview`, `@types/http-proxy`)
- **Fix CI pipeline ordering** — run `check:types` before `build` since `zile` strips the `scripts` section from `package.json` during build
- **Fix pnpm workspace script resolution** — use explicit `pnpm run check:types` to avoid recursive exec failure
- **Constrain oxfmt** to code files only (ignore `*.json`, `*.yaml`, `.github/`, etc.)
- **Migrate from deprecated `tempoTestnet` to `tempoModerato`** across test configs, CI workflow, and JSDoc examples