### PR TITLE
Fix inconsistent account usage

### DIFF
--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -450,7 +450,6 @@ export declare namespace keyManager {
  * import { Handler } from 'tempo.ts/server'
  *
  * const client = createClient({
- *   account: privateKeyToAccount('0x...'),
  *   chain: tempoModerato.extend({
  *     feeToken: '0x20c0000000000000000000000000000000000001',
  *   }),


### PR DESCRIPTION
Remove account from `createClient` in the Bun `feePayer` example.

In other examples (Node.js, Hono, Deno, etc.), the account is only passed to `Handler.feePayer`, while the client is configured with chain and transport only.

Keeping this consistent avoids confusion about where the fee payer account should be defined.