### PR TITLE
chore: add pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,5 @@ catalog:
 onlyBuiltDependencies:
   - esbuild
   - simple-git-hooks
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
Adds `minimumReleaseAge: 1440` (1 day) to pnpm config as a supply-chain attack mitigation. This prevents pnpm from installing packages published less than 24 hours ago.

See: https://pnpm.io/settings#minimumreleaseage

Prompted by: horsefacts