### PR TITLE
feat(server): add fee payer preflight helper

### DIFF
--- a/src/server/Handler.test.ts
+++ b/src/server/Handler.test.ts
@@ -4,11 +4,11 @@ import { Hono } from 'hono'
 import type { RpcRequest } from 'ox'
 import * as Base64 from 'ox/Base64'
 import * as Hex from 'ox/Hex'
-import { sendTransactionSync } from 'viem/actions'
+import { sendTransactionSync, signTransaction } from 'viem/actions'
 import { withFeePayer } from 'viem/tempo'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
-import { accounts, getClient, http } from '../../test/server/config.js'
+import { accounts, addresses, getClient, http } from '../../test/server/config.js'
 import { createServer, type Server } from '../../test/server/utils.js'
 import * as Handler from './Handler.js'
 import * as Kv from './Kv.js'
@@ -1212,5 +1212,57 @@ describe('feePayer', () => {
         }
       `)
     })
+  })
+})
+
+describe('feePayerPreflight', () => {
+  const userAccount = accounts[9]!
+  const feePayerAccount = accounts[0]!
+
+  test('behavior: parses a signed fee payer request', async () => {
+    const client = getClient({ account: userAccount })
+    const serialized = await signTransaction(client, {
+      account: userAccount,
+      feeToken: addresses.alphaUsd,
+      to: '0x0000000000000000000000000000000000000000',
+    })
+
+    const result = await Handler.feePayerPreflight({
+      request: {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_signRawTransaction',
+        params: [serialized],
+      },
+    })
+
+    expect(result.method).toBe('eth_signRawTransaction')
+    expect(result.request.method).toBe('eth_signRawTransaction')
+    expect(result.transaction.from).toBe(userAccount.address.toLowerCase())
+    expect(result.sponsoredTransaction.feePayer).toBeUndefined()
+  })
+
+  test('behavior: simulates a sponsored transaction', async () => {
+    const client = getClient({ account: userAccount })
+    const serialized = await signTransaction(client, {
+      account: userAccount,
+      feeToken: addresses.alphaUsd,
+      to: '0x0000000000000000000000000000000000000000',
+    })
+
+    const result = await Handler.feePayerPreflight({
+      client: getClient(),
+      feePayer: feePayerAccount,
+      request: {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_signRawTransaction',
+        params: [serialized],
+      },
+      simulate: true,
+    })
+
+    expect(result.sponsoredTransaction.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    expect(result.estimateGas).toBeGreaterThan(0n)
   })
 })

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -552,19 +552,9 @@ export function feePayer(options: feePayer.Options) {
           ),
         )
 
-      const serialized = request.params?.[0] as `0x76${string}`
-
-      if (!serialized?.startsWith('0x76') && !serialized?.startsWith('0x78'))
-        throw new RpcResponse.InvalidParamsError({
-          message: 'Only Tempo (0x76/0x78) transactions are supported.',
-        })
-
-      const transaction = Transaction.deserialize(serialized) as any
-
-      if (!transaction.signature || !transaction.from)
-        throw new RpcResponse.InvalidParamsError({
-          message: 'Transaction must be signed by the sender before fee payer signing.',
-        })
+      const { transaction } = await feePayerPreflight({
+        request,
+      })
 
       const serializedTransaction = await signTransaction(client, {
         ...transaction,
@@ -598,6 +588,56 @@ export function feePayer(options: feePayer.Options) {
   return router
 }
 
+export async function feePayerPreflight(options: feePayerPreflight.Options) {
+  const request = RpcRequest.from(options.request as any)
+  const method = request.method as string
+
+  if (
+    method !== 'eth_signRawTransaction' &&
+    method !== 'eth_sendRawTransaction' &&
+    method !== 'eth_sendRawTransactionSync'
+  )
+    throw new RpcResponse.MethodNotSupportedError({
+      message: `Method not supported: ${request.method}`,
+    })
+
+  const serialized = request.params?.[0] as `0x76${string}`
+
+  if (!serialized?.startsWith('0x76') && !serialized?.startsWith('0x78'))
+    throw new RpcResponse.InvalidParamsError({
+      message: 'Only Tempo (0x76/0x78) transactions are supported.',
+    })
+
+  const transaction = Transaction.deserialize(serialized) as any
+
+  if (!transaction.signature || !transaction.from)
+    throw new RpcResponse.InvalidParamsError({
+      message: 'Transaction must be signed by the sender before fee payer signing.',
+    })
+
+  const feePayer =
+    typeof options.feePayer === 'string' ? options.feePayer : options.feePayer?.address
+
+  const sponsoredTransaction = feePayer ? { ...transaction, feePayer } : transaction
+
+  const estimateGas = options.simulate
+    ? BigInt(
+        await (options.client as any).request({
+          method: 'eth_estimateGas',
+          params: [sponsoredTransaction],
+        }),
+      )
+    : undefined
+
+  return {
+    estimateGas,
+    method,
+    request,
+    sponsoredTransaction,
+    transaction,
+  } satisfies feePayerPreflight.Result
+}
+
 export declare namespace feePayer {
   export type Options = from.Options & {
     /** Account to use as the fee payer. */
@@ -618,6 +658,39 @@ export declare namespace feePayer {
           transport: Transport
         }
     >
+}
+
+export declare namespace feePayerPreflight {
+  export type Result = {
+    /** Gas estimate for the parsed request if simulation is enabled. */
+    estimateGas?: bigint | undefined
+    /** Parsed JSON-RPC method. */
+    method: feePayer.PolicyContext['method']
+    /** Original JSON-RPC request. */
+    request: RpcRequest.RpcRequest
+    /** Parsed Tempo transaction. */
+    transaction: ReturnType<typeof Transaction.deserialize>
+    /** Parsed transaction with the provided fee payer attached, if any. */
+    sponsoredTransaction: ReturnType<typeof Transaction.deserialize>
+  }
+
+  export type Options = {
+    /** JSON-RPC request to inspect. */
+    request: RpcRequest.RpcRequest | unknown
+  } & OneOf<
+    | {
+        /** Disable simulation. */
+        simulate?: false | undefined
+      }
+    | {
+        /** Enable `eth_estimateGas` simulation. */
+        simulate: true
+        /** Client used to simulate the request. */
+        client: Client
+        /** Optional fee payer to attach before simulation. */
+        feePayer?: LocalAccount | `0x${string}` | undefined
+      }
+  >
 }
 
 /** @internal */


### PR DESCRIPTION
Adds a reusable `Handler.feePayerPreflight(...)` helper for server-side sponsorship flows.

The helper parses and validates sender-signed Tempo transactions before fee payer signing, and can optionally run `eth_estimateGas` simulation with an attached fee payer address. `Handler.feePayer` now reuses the same parsing path internally.

This is aimed at developers who want a Rabby-like preflight step before deciding whether to sponsor or forward a transaction.
