### PR TITLE
chore: switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,4 +48,3 @@ jobs:
           version: pnpm changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+provenance=true


### PR DESCRIPTION
Drop long-lived `NPM_TOKEN` secret in favor of npm OIDC trusted publishing (provenance). The changesets job already has `id-token: write` — this just adds `provenance=true` to `.npmrc` and removes the token env var.

**Before merging:** configure npm trusted publishing for the `tempo.ts` package on npmjs.com:
- Provider: GitHub Actions
- Repository: `tempoxyz/tempo-ts`
- Workflow: `main.yml`
- Environment: (leave blank)

After that's set, the `NPM_TOKEN` secret can be removed from the repo settings.

Prompted by: horsefacts