### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,10 +5,10 @@ runs:
   using: 'composite'
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches: [main]
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -11,7 +13,8 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-    secrets: inherit
+    secrets:
+      VITE_RPC_CREDENTIALS: ${{ secrets.VITE_RPC_CREDENTIALS }}
 
   changesets:
     name: Changesets
@@ -25,19 +28,18 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-          submodules: 'recursive'
-          token: ${{ secrets.GH_PAT }}
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
       - name: PR or publish
         id: changesets
-        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # 06245a4e0a36c064a573d4150030f5ec548e4fcc
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,10 +9,9 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: 'recursive'
-          token: ${{ secrets.GH_PAT }}
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -11,4 +13,5 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-    secrets: inherit
+    secrets:
+      VITE_RPC_CREDENTIALS: ${{ secrets.VITE_RPC_CREDENTIALS }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,7 +1,13 @@
 name: Verify
 on:
   workflow_call:
+    secrets:
+      VITE_RPC_CREDENTIALS:
+        required: false
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   checks:
@@ -10,10 +16,9 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: 'recursive'
-          token: ${{ secrets.GH_PAT }}
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
@@ -38,16 +43,15 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: 'recursive'
-          token: ${{ secrets.GH_PAT }}
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
       - name: Setup Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
 
       - name: Run tests
         run: pnpm test --bail=1


### PR DESCRIPTION
- Remove `GH_PAT` and `submodules: recursive` from all checkout steps — this repo has no submodules, and the PAT was causing CI failures on PRs
- Pin all actions to SHAs (`actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, `docker/setup-docker-action`, `changesets/action`)
- Add `persist-credentials: false` to all checkout steps
- Add top-level `permissions: {}` to `main.yml`, `pull-request.yml`; `contents: read` to `verify.yml`
- Replace `secrets: inherit` with explicit `secrets:` — only passes `VITE_RPC_CREDENTIALS`

This should also fix CI on PRs — the previous `GH_PAT` token wasn't available in PR context.

Prompted by: horsefacts