### PR TITLE
docs: mark tempo-ts archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@
 
 # Tempo TypeScript SDK
 
+> [!IMPORTANT]
+> This repository is archived. New Tempo TypeScript integrations should use the
+> maintained packages listed below instead of adding new `tempo.ts` usage.
+
+## Migration paths
+
+| `tempo.ts` usage                         | Use instead                                                                                                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fee payer / sponsored transaction server | [`accounts`](https://github.com/tempoxyz/accounts) via `accounts/server` `Handler.relay({ feePayer })`; see the [fee payer example](https://github.com/tempoxyz/accounts/tree/main/examples/fee-payer) and [fee sponsorship guide](https://accounts.tempo.xyz/docs/guides/fee-sponsorship). |
+| `tempo.ts/viem` and chain definitions    | [`viem`](https://github.com/wevm/viem), where Tempo chain support has been upstreamed.                                                            |
+| `tempo.ts/wagmi`                         | [`wagmi/tempo`](https://wagmi.sh) or [`@wagmi/core/tempo`](https://wagmi.sh/core), where Tempo support has been upstreamed.                       |
+| `tempo.ts/ox`                            | [`ox/tempo`](https://github.com/wevm/ox).                                                                                                         |
+| `tempo.ts/prool`                         | [`prool`](https://github.com/wevm/prool), which includes the Tempo instance directly.                                                             |
+
 ## Install
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 	},
 	"[!start-pkg]": "",
 	"name": "tempo.ts",
+	"description": "Archived TypeScript tooling for Tempo. Use accounts, viem, wagmi, ox, or prool for maintained integrations.",
 	"type": "module",
 	"version": "0.14.2",
 	"dependencies": {


### PR DESCRIPTION
## Summary
- mark tempo-ts as archived in the README
- add migration paths for fee payer functionality, viem/chains, wagmi, ox, and prool
- add package metadata noting the archived status

## Testing
- jq empty package.json
- git diff --check

Full `pnpm check` was not run because pnpm is not installed in the sandbox and Corepack failed to download pnpm@10.18.3 from the npm registry.